### PR TITLE
Fix libwrapper warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.0.10
+- Removes redundant Sheet Overrides, should stop warning from popping up when selecting item piles actors.
+
 # v1.0.9
 - (Haxxer) Updated sheet overrides to override all classes
 - This should fix an issue in v13 where merchant sheet not overriding default loot sheet when actor from journal or sidebar.

--- a/module.js
+++ b/module.js
@@ -130,32 +130,7 @@ Hooks.once("item-piles-ready", async () => {
 
 		"VAULT_STYLES": [],
 
-		"SYSTEM_HOOKS": () => {},
-
-		"SHEET_OVERRIDES": () => {
-			const sheetOverrides = Object.keys(CONFIG.Actor.sheetClasses).map(str => {
-			    return Object.keys(CONFIG.Actor.sheetClasses[str]).map(sheet => {
-			        return `CONFIG.Actor.sheetClasses.${str}.["${sheet}"].cls.prototype.render`;
-			    })
-			}).flat()
-
-			const method = function (wrapped, forced, options, ...args) {
-				const renderItemPileInterface = Hooks.call(game.itempiles.CONSTANTS.HOOKS.PRE_RENDER_SHEET, this.document, forced, options) === false;
-				if (this._state > Application.RENDER_STATES.NONE) {
-					if (renderItemPileInterface) {
-						wrapped(forced, options, ...args)
-					} else {
-						return wrapped(forced, options, ...args)
-					}
-				}
-				if (renderItemPileInterface) return;
-				return wrapped(forced, options, ...args);
-			};
-
-			for(const override of sheetOverrides){
-				libWrapper.register("itempiles-pf2e", override, method, "MIXED");
-			}
-		}
+		"SYSTEM_HOOKS": () => {}
 	}
 
 	await game.itempiles.API.addSystemIntegration(data);

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "itempiles-pf2e",
   "title": "Item Piles: PF2e",
   "description": "This module adds support for the PF2e system within the Item Piles module",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "compatibility": {
     "minimum": "12",
     "verified": "13",
@@ -27,7 +27,7 @@
         "manifest": "https://github.com/fantasycalendar/FoundryVTT-ItemPiles/releases/latest/download/module.json",
         "compatibility": {
           "minimum": "3.2.15",
-          "verified": "3.2.16"
+          "verified": "3.2.27"
         }
       }
     ],
@@ -37,7 +37,7 @@
         "type": "system",
         "compatibility": {
           "minimum": "6",
-          "verified": "7.2.2"
+          "verified": "7.8.0"
         }
       }
     ]


### PR DESCRIPTION
Removes redundant Sheet Overrides, should stop warning from popping up when selecting item piles actors.

Fixes #5 