### PR TITLE
Bump compatibility for FVTT v14 and PF2e 8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.1.0
+- Verified for v14 compatibility.
+- Core Item Piles has dropped support for v12, so I have has as well.
+- This module continues to only work for PF2e. SF2e support has hit a roadblock.
+
 # v1.0.10
 - Removes redundant Sheet Overrides, should stop warning from popping up when selecting item piles actors.
 

--- a/module.json
+++ b/module.json
@@ -2,9 +2,9 @@
   "id": "itempiles-pf2e",
   "title": "Item Piles: PF2e",
   "description": "This module adds support for the PF2e system within the Item Piles module",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "compatibility": {
-    "minimum": "12",
+    "minimum": "13",
     "verified": "14",
     "maximum": "14"
   },
@@ -26,8 +26,8 @@
         "type": "module",
         "manifest": "https://github.com/fantasycalendar/FoundryVTT-ItemPiles/releases/latest/download/module.json",
         "compatibility": {
-          "minimum": "3.2.15",
-          "verified": "3.2.32"
+          "minimum": "3.3.1",
+          "verified": "3.3.1"
         }
       }
     ],
@@ -36,8 +36,8 @@
         "id": "pf2e",
         "type": "system",
         "compatibility": {
-          "minimum": "6",
-          "verified": "8.1.1"
+          "minimum": "7",
+          "verified": "8.1.2"
         }
       }
     ]

--- a/module.json
+++ b/module.json
@@ -5,8 +5,8 @@
   "version": "1.0.10",
   "compatibility": {
     "minimum": "12",
-    "verified": "13",
-    "maximum": "13"
+    "verified": "14",
+    "maximum": "14"
   },
   "authors": [
     {
@@ -27,7 +27,7 @@
         "manifest": "https://github.com/fantasycalendar/FoundryVTT-ItemPiles/releases/latest/download/module.json",
         "compatibility": {
           "minimum": "3.2.15",
-          "verified": "3.2.27"
+          "verified": "3.2.32"
         }
       }
     ],
@@ -37,7 +37,7 @@
         "type": "system",
         "compatibility": {
           "minimum": "6",
-          "verified": "7.8.0"
+          "verified": "8.1.1"
         }
       }
     ]


### PR DESCRIPTION
## What

`module.json` only:

- `compatibility.verified` / `compatibility.maximum`: `13` → `14`
- `relationships.requires.item-piles.compatibility.verified`: `3.2.27` → `3.2.32` (current Item Piles release)
- `relationships.systems.pf2e.compatibility.verified`: `7.8.0` → `8.1.1`

No runtime changes.

## Why

The integration `module.js` is still correct on FVTT 14.360 + PF2e 8.1.1:

- `game.pf2e.Coins` is still exposed in `initSafe` (PF2e `pf2e.mjs` ~line 70694) and `Coins#copperValue` works the same.
- `system.price.value` / `system.price.per` and `system.bulk.value` paths are unchanged.
- `system.traits.rarity` and rarity translation keys (`PF2E.TraitCommon` …) are unchanged.
- The `equipment-srd` compendium retains the same coin item IDs (`JuNPeK5Qm1w6wpb4` / `B6B7tBWJSqOBz5zz` / `5Ew82vBF9YfaiY9f` / `lzJ8AVhRcbFul5fh`); the legacy 4-segment UUIDs (`Compendium.pf2e.equipment-srd.<id>`) used here are auto-rewritten with the `Item.` document-type segment by v14's `parseUuid`.
- `linkToActorSize` / `autoscale` token flags are still part of the PF2e prototype-token namespace.

## Tested

- FVTT 14.360 stable + PF2e 8.1.1 + Item Piles 3.2.32.
- Currency dropping / consolidation, merchant Buy/Sell with rarity + bulk columns, unidentified-item GM-only preview filter all work.
